### PR TITLE
Fix for side view sticking when the device rotates when the app isn't active or not visible

### DIFF
--- a/PaneViewController.podspec
+++ b/PaneViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PaneViewController"
-  s.version      = "5.0.5"
+  s.version      = "5.0.6"
   s.summary      = "A side drawer controller"
   s.homepage     = "https://github.com/GreenJell0/PaneViewController"
   s.description  = <<-DESC

--- a/PaneViewController/PaneViewController.swift
+++ b/PaneViewController/PaneViewController.swift
@@ -338,10 +338,6 @@ open class PaneViewController: UIViewController {
 
                 if isSecondaryViewShowing {
                     secondaryViewModalContainerShowingLeadingConstraint?.constant = secondaryViewModalContainerOpenLocation
-                } else if widthScreenWillTransitionTo != view.frame.width {
-                    widthScreenWillTransitionTo = view.frame.width
-                    updateSecondaryViewLocationForNewWidth(view.frame.width)
-                    updateSizeClassOfChildViewControllers()
                 }
             } else {
                 secondaryViewModalContainerOpenLocation = 0
@@ -351,9 +347,6 @@ open class PaneViewController: UIViewController {
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-
-        guard UIApplication.shared.applicationState == .active
-            else { return }
 
         widthScreenWillTransitionTo = size.width
         updateSecondaryViewLocationForNewWidth(size.width)
@@ -520,11 +513,11 @@ open class PaneViewController: UIViewController {
         if view.frame.width >= minimumSideBySideScreenWidth {
             blurIfNeeded()
             primaryViewWillChangeWidthObservers.fire(primaryViewController.view)
-            updateSecondaryViewSideBySideConstraint(forPinningState: paneViewPinningState)
         } else {
             secondaryViewModalContainerShowingLeadingConstraint?.isActive = false
             secondaryViewModalContainerHiddenLeadingConstraint?.isActive = true
         }
+        updateSecondaryViewSideBySideConstraint(forPinningState: paneViewPinningState)
 
         UIView.animate(withDuration: animated ? 0.3 : 0, animations: {
             self.view.layoutIfNeeded()

--- a/PaneViewController/PaneViewController.swift
+++ b/PaneViewController/PaneViewController.swift
@@ -534,7 +534,9 @@ open class PaneViewController: UIViewController {
                 break
             }
 
-            self.secondaryViewDidCloseObservers.fire()
+            if animated {
+                self.secondaryViewDidCloseObservers.fire()
+            }
         })
     }
     


### PR DESCRIPTION
- rotation handling was being ignored if the app was inactive or in the background, which resulted in a bad state when coming back to the foreground
- rotation handling when not the front view (e.g. while full screen video playing) was getting into a bad state where it thought the side view was closed but constraints keeping it open hadn't been removed.