### PR TITLE
Removed close and open on size changes

### DIFF
--- a/Sources/PaneViewController/PaneViewController.swift
+++ b/Sources/PaneViewController/PaneViewController.swift
@@ -678,11 +678,6 @@ open class PaneViewController: UIViewController {
     }
     
     private func updateSecondaryViewLocationForNewWidth(_ newWidth: CGFloat) {
-        if isSecondaryViewShowing {
-            dismissSecondaryViewAnimated(false)
-            showSecondaryViewAnimated(false)
-        }
-
         if newWidth >= minimumSideBySideScreenWidth {
             presentationMode = .sideBySide
             sideHandleTouchView.isUserInteractionEnabled = true


### PR DESCRIPTION
We ran into an issue where our listener for the draw closing was getting triggered on screen rotation because of this code deliberately closing and opening again on any size changes. This means we had to choose between a "pause on rotate behavior" or "continue playing when the drawer is closed from tap to close" behavior. 

After removing it and reviewing, I couldn't find the purpose for this being added in the first place. Everything in our limited tests seemed to go smoothly, but I understand it was limited. 

Thoughts?