### PR TITLE
Prevent pan gesture from interfereing with other gestures in the app

### DIFF
--- a/Sources/PaneViewController/PaneViewController.swift
+++ b/Sources/PaneViewController/PaneViewController.swift
@@ -751,6 +751,13 @@ extension PaneViewController: UIGestureRecognizerDelegate {
         return true
     }
     
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer == panGestureRecognizer
+        else { return true }
+        
+        return canOpenSecondaryViewWithSwipe || isSecondaryViewShowing
+    }
+    
 }
 
 public protocol PaneViewControllerDelegate: AnyObject {


### PR DESCRIPTION
The pan gesture doesn't need to fire if the sidebar is closed and `canOpenSecondaryViewWithSwipe == false`. This was interfering with re-ordering in SwiftUI Lists in < iOS 16.